### PR TITLE
fix: 恢复群组绑定逻辑，修复群聊签到统计显示空列表问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -243,6 +243,15 @@ class SklandPlugin(Star):
 
         if is_group:
             # 群聊模式
+            # 如果发送者已绑定，自动添加到该群
+            if user_id in users_data:
+                groups = await self.get_kv_data("groups", {})
+                if group_id not in groups:
+                    groups[group_id] = []
+                if user_id not in groups[group_id]:
+                    groups[group_id].append(user_id)
+                    await self.put_kv_data("groups", groups)
+            
             message_lines = ["📊 森空岛签到统计", "═══════════════", "方舟 | 终末 | 昵称", "-----------------"]
             group_users = (await self.get_kv_data("groups", {})).get(group_id, [])
             for uid in group_users:


### PR DESCRIPTION
## 🐛 修复的问题

在群聊中执行 `/skd` 时，签到统计显示空列表，没有任何用户。

## 🔍 根本原因

PR #7 重构时删除了 `_add_user_to_group()` 方法和相关的群组绑定逻辑，导致：
- `groups` 数据永远是空的 `{}`
- 群聊查询时找不到任何用户

## ✅ 解决方案

在群聊执行 `/skd` 命令时，自动将已登录的发送者添加到该群的用户列表中：

```python
# 如果发送者已绑定，自动添加到该群
if user_id in users_data:
    groups = await self.get_kv_data("groups", {})
    if group_id not in groups:
        groups[group_id] = []
    if user_id not in groups[group_id]:
        groups[group_id].append(user_id)
        await self.put_kv_data("groups", groups)
```

## 🧪 测试建议

1. 私聊使用 `/skdlogin <token>` 登录
2. 在群聊中发送 `/skd`
3. 应该能看到自己出现在签到统计列表中

## 📝 相关

Fixes: 群聊签到统计显示空列表的问题
Related: #7