### PR TITLE
ci: 修改打包方式，直接打包根目录

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,21 +35,11 @@ jobs:
           VERSION=${{ steps.version.outputs.version }}
           PLUGIN_NAME="astrbot_plugin_skland"
           
-          # Create release directory
-          mkdir -p release/${PLUGIN_NAME}
+          # Create zip archive (directly from root, exclude .git and .github)
+          zip -r ${PLUGIN_NAME}-${VERSION}.zip . -x "*.git*" -x "*__pycache__*" -x "*.pyc"
           
-          # Copy plugin files
-          cp -r ${PLUGIN_NAME}/* release/${PLUGIN_NAME}/
-          
-          # Create zip archive
-          cd release
-          zip -r ../${PLUGIN_NAME}-${VERSION}.zip ${PLUGIN_NAME}
-          cd ..
-          
-          # Also create a tar.gz
-          cd release
-          tar -czvf ../${PLUGIN_NAME}-${VERSION}.tar.gz ${PLUGIN_NAME}
-          cd ..
+          # Create tar.gz
+          tar -czvf ${PLUGIN_NAME}-${VERSION}.tar.gz --exclude='.git*' --exclude='__pycache__' --exclude='*.pyc' .
 
       - name: Generate changelog
         id: changelog


### PR DESCRIPTION
## 📦 改进内容

修改 GitHub Actions 的打包逻辑，让用户下载后解压即可使用。

## 🔄 对比

### 之前
```
astrbot_plugin_skland-v1.0.0.zip
└── 解压后
    └── astrbot_plugin_skland/
        ├── main.py
        ├── README.md
        └── ...
```
❌ 用户需要手动移动文件到 plugins 目录

### 现在
```
astrbot_plugin_skland-v1.0.0.zip
└── 解压后
    ├── main.py
    ├── README.md
    ├── metadata.yaml
    └── ...
```
✅ 直接解压到 plugins/astrbot_plugin_skland 即可使用

## 🔧 技术细节

- 使用 `zip -r . -x` 从根目录打包
- 排除 `.git*`、`__pycache__`、`*.pyc` 等无关文件
- tar.gz 同样采用相同逻辑

## 💡 用户体验提升

下载 → 解压到 plugins 目录 → 完成，一步到位！