### PR TITLE
fix: 修复登录鉴权“设备信息无效”

### DIFF
--- a/skland_api.py
+++ b/skland_api.py
@@ -25,6 +25,7 @@ from Crypto.Util.Padding import pad
 
 # Constants from Rust source
 USER_AGENT = "Mozilla/5.0 (Linux; Android 12; SM-A5560 Build/V417IR; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/101.0.4951.61 Safari/537.36; SKLand/1.52.1"
+LOGIN_USER_AGENT = "Skland/1.0.1 (com.hypergryph.skland; build:100001014; Android 31; ) Okhttp/4.11.0"
 
 DES_RULE = {
     "appId": {"cipher": "DES", "is_encrypt": 1, "key": "uy7mzc4h", "obfuscated_name": "xx"},
@@ -342,10 +343,19 @@ class SklandAPI:
             "dId": did,
         }
 
+    def _get_login_headers(self, did: str) -> dict:
+        """Get headers for Hypergryph authentication requests"""
+        return {
+            "User-Agent": LOGIN_USER_AGENT,
+            "Accept-Encoding": "gzip",
+            "Connection": "close",
+            "dId": did,
+        }
+
     async def get_authorization(self, user_token: str) -> str:
         """Get authorization code from user token"""
         did = await self.get_device_id()
-        headers = self._get_base_headers(did)
+        headers = self._get_login_headers(did)
 
         response = await self._request(
             "POST",
@@ -362,7 +372,7 @@ class SklandAPI:
     async def get_credential(self, authorization: str) -> Credential:
         """Get credential from authorization code"""
         did = await self.get_device_id()
-        headers = self._get_base_headers(did)
+        headers = self._get_login_headers(did)
 
         response = await self._request(
             "POST",


### PR DESCRIPTION
## 问题说明

AstrBot 自动签到时出现以下错误：

```text
[10:00:00.784] [astrbot_plugin_skland] [ERRO] [v4.27.4] [astrbot_plugin_skland.main:173]: 用户 **** 自动签到失败: Credential failed: 设备信息无效
```

登录流程中，OAuth 授权码可以正常获取，但在调用
`generate_cred_by_code` 换取森空岛凭据时失败：

```text
Credential failed: 设备信息无效
```

当前实现的 `get_authorization()` 和 `get_credential()` 复用了业务 API
请求头，其中包含旧版 WebView `User-Agent` 和 `X-Requested-With`。

森空岛登录鉴权接口会校验数美 `dId` 与客户端设备身份。认证请求携带的客户端
身份与接口当前要求不一致时，服务端会拒绝换取凭据并返回“设备信息无效”。

## 修改内容

- 新增原生森空岛 App 登录 `User-Agent`
- 新增独立的 `_get_login_headers()` 登录请求头
- 登录请求头仅携带：
  - `User-Agent`
  - `Accept-Encoding`
  - `Connection`
  - `dId`
- `get_authorization()` 改用登录专用请求头
- `get_credential()` 改用登录专用请求头
- 保留现有 `_get_base_headers()`，不改变角色查询、签到及签名请求行为

本仓库现有的 25 条 `DES_RULE` 已与参考实现一致，因此本次不修改设备指纹
加密规则，以保持改动范围最小。

## 参考实现

- [kelai141/astrbot_plugin_skyland#4：修复登录鉴权“设备信息无效”](https://github.com/kelai141/astrbot_plugin_skyland/pull/4)
- [本仓库 PR #17 中的登录请求头实现](https://github.com/Azincc/astrbot_plugin_skland/pull/17)

## 影响范围

本次改动仅影响 OAuth 授权和换取 cred 时使用的请求头。
